### PR TITLE
feat: lookup functionality for subjects

### DIFF
--- a/api/src/main/java/com/oviva/spicegen/api/LookupSuspects.java
+++ b/api/src/main/java/com/oviva/spicegen/api/LookupSuspects.java
@@ -1,0 +1,26 @@
+package com.oviva.spicegen.api;
+
+import com.oviva.spicegen.api.internal.LookupSuspectsImpl;
+
+public interface LookupSuspects<T extends ObjectRef> {
+
+  String permission();
+
+  ObjectRef resource();
+
+  ObjectRefFactory<T> subjectType();
+
+  static <T extends ObjectRef> Builder<T> newBuilder() {
+    return LookupSuspectsImpl.newBuilder();
+  }
+
+  interface Builder<T extends ObjectRef> {
+    Builder<T> permission(String permission);
+
+    Builder<T> resource(ObjectRef resource);
+
+    Builder<T> subjectType(ObjectRefFactory<T> subjectType);
+
+    LookupSuspects<T> build();
+  }
+}

--- a/api/src/main/java/com/oviva/spicegen/api/ObjectRefFactory.java
+++ b/api/src/main/java/com/oviva/spicegen/api/ObjectRefFactory.java
@@ -1,0 +1,9 @@
+package com.oviva.spicegen.api;
+
+public interface ObjectRefFactory<T extends ObjectRef> {
+  Class<T> getRefClass();
+
+  T create(String id);
+
+  String kind();
+}

--- a/api/src/main/java/com/oviva/spicegen/api/PermissionService.java
+++ b/api/src/main/java/com/oviva/spicegen/api/PermissionService.java
@@ -1,5 +1,7 @@
 package com.oviva.spicegen.api;
 
+import java.util.Iterator;
+
 public interface PermissionService {
 
   /**
@@ -20,4 +22,6 @@ public interface PermissionService {
    * @return true it the subject is permitted, false otherwise
    */
   boolean checkPermission(CheckPermission checkPermission);
+
+  <T extends ObjectRef> Iterator<T> lookupSubjects(LookupSuspects<T> lookupSuspects);
 }

--- a/api/src/main/java/com/oviva/spicegen/api/internal/LookupSuspectsImpl.java
+++ b/api/src/main/java/com/oviva/spicegen/api/internal/LookupSuspectsImpl.java
@@ -1,0 +1,50 @@
+package com.oviva.spicegen.api.internal;
+
+import com.oviva.spicegen.api.LookupSuspects;
+import com.oviva.spicegen.api.ObjectRef;
+import com.oviva.spicegen.api.ObjectRefFactory;
+
+public record LookupSuspectsImpl<T extends ObjectRef>(
+    String permission, ObjectRef resource, ObjectRefFactory<T> subjectType)
+    implements LookupSuspects<T> {
+
+  private LookupSuspectsImpl(Builder<T> builder) {
+    this(builder.permission, builder.resource, builder.subjectType);
+  }
+
+  public static <T extends ObjectRef> Builder<T> newBuilder() {
+    return new Builder<>();
+  }
+
+  public static final class Builder<T extends ObjectRef> implements LookupSuspects.Builder<T> {
+    private String permission;
+    private ObjectRef resource;
+    private ObjectRefFactory<T> subjectType;
+
+    @Override
+    public Builder<T> permission(String permission) {
+      this.permission = permission;
+      return this;
+    }
+
+    @Override
+    public Builder<T> resource(ObjectRef resource) {
+      this.resource = resource;
+      return this;
+    }
+
+    @Override
+    public Builder<T> subjectType(ObjectRefFactory<T> subjectType) {
+      this.subjectType = subjectType;
+      return this;
+    }
+
+    @Override
+    public LookupSuspects<T> build() {
+      if (permission == null || resource == null || subjectType == null) {
+        throw new IllegalStateException("Permission, resource, and subjectType must be set");
+      }
+      return new LookupSuspectsImpl<>(this);
+    }
+  }
+}

--- a/example/src/test/java/com/oviva/spicegen/example/ExampleTest.java
+++ b/example/src/test/java/com/oviva/spicegen/example/ExampleTest.java
@@ -1,12 +1,17 @@
 package com.oviva.spicegen.example;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.authzed.api.v1.PermissionsServiceGrpc;
 import com.authzed.api.v1.SchemaServiceGrpc;
 import com.authzed.api.v1.WriteSchemaRequest;
 import com.authzed.grpcutil.BearerToken;
-import com.oviva.spicegen.api.*;
+import com.oviva.spicegen.api.Consistency;
+import com.oviva.spicegen.api.PermissionService;
+import com.oviva.spicegen.api.SubjectRef;
+import com.oviva.spicegen.api.UpdateRelationships;
 import com.oviva.spicegen.permissions.refs.DocumentRef;
 import com.oviva.spicegen.permissions.refs.FolderRef;
 import com.oviva.spicegen.permissions.refs.TeamRef;
@@ -16,6 +21,10 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -109,10 +118,18 @@ class ExampleTest {
             document.checkRead(
                 SubjectRef.ofObject(user), Consistency.atLeastAsFreshAs(consistencyToken))));
 
-    assertTrue(
-        permissionService.checkPermission(
-            document.checkRead(
-                SubjectRef.ofObject(user2), Consistency.atLeastAsFreshAs(consistencyToken))));
+    Iterator<UserRef> usersAllowedToRead =
+        permissionService.lookupSubjects(document.lookupReadUser());
+    assertTrue(usersAllowedToRead.hasNext());
+    // usersAllowedToRead contains both userId and user2
+    var userIds =
+        StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(usersAllowedToRead, Spliterator.ORDERED), false)
+            .map(UserRef::id)
+            .toList();
+    assertEquals(2, userIds.size());
+    assertTrue(userIds.contains(user.id()));
+    assertTrue(userIds.contains(user2.id()));
   }
 
   private String loadSchema() {

--- a/generator/src/main/java/com/oviva/spicegen/generator/internal/SpiceDbClientGeneratorImpl.java
+++ b/generator/src/main/java/com/oviva/spicegen/generator/internal/SpiceDbClientGeneratorImpl.java
@@ -2,15 +2,34 @@ package com.oviva.spicegen.generator.internal;
 
 import static com.oviva.spicegen.generator.utils.TextUtils.toPascalCase;
 
-import com.oviva.spicegen.api.*;
+import com.oviva.spicegen.api.CheckPermission;
+import com.oviva.spicegen.api.Consistency;
+import com.oviva.spicegen.api.LookupSuspects;
+import com.oviva.spicegen.api.ObjectRef;
+import com.oviva.spicegen.api.ObjectRefFactory;
+import com.oviva.spicegen.api.SubjectRef;
+import com.oviva.spicegen.api.UpdateRelationship;
 import com.oviva.spicegen.generator.Options;
 import com.oviva.spicegen.generator.SpiceDbClientGenerator;
 import com.oviva.spicegen.generator.utils.TextUtils;
-import com.oviva.spicegen.model.*;
-import com.squareup.javapoet.*;
+import com.oviva.spicegen.model.ObjectDefinition;
+import com.oviva.spicegen.model.ObjectTypeRef;
+import com.oviva.spicegen.model.Permission;
+import com.oviva.spicegen.model.Relation;
+import com.oviva.spicegen.model.Schema;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.TypeSpec.Builder;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 import java.util.UUID;
 import javax.lang.model.element.Modifier;
 import org.slf4j.Logger;
@@ -89,6 +108,16 @@ public class SpiceDbClientGeneratorImpl implements SpiceDbClientGenerator {
 
   private void generateRefs(Schema spec) {
 
+    TypeSpec.Builder factories =
+        TypeSpec.classBuilder("ObjectRefFactories")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            // private ctor to prevent instantiation
+            .addMethod(
+                MethodSpec.constructorBuilder()
+                    .addModifiers(Modifier.PRIVATE)
+                    .addStatement("throw new AssertionError(\"No instances allowed\")")
+                    .build());
+
     for (ObjectDefinition definition : spec.definitions()) {
       var className = TextUtils.capitalize(TextUtils.toCamelCase(definition.name())) + "Ref";
       var typedRef = TypeSpec.classBuilder(className).build();
@@ -160,10 +189,69 @@ public class SpiceDbClientGeneratorImpl implements SpiceDbClientGenerator {
       addUpdateMethods(typedRefBuilder, definition);
 
       addCheckMethods(typedRefBuilder, definition);
+      addLookupMethods(typedRefBuilder, definition);
 
       typedRef = typedRefBuilder.build();
       writeSource(typedRef, ".refs");
+      createFactoryInstance(ClassName.bestGuess(className), factories);
     }
+
+    TypeSpec factoriesClass = factories.build();
+
+    writeSource(factoriesClass, ".refs");
+  }
+
+  private static void createFactoryInstance(ClassName ref, Builder factories) {
+    ParameterizedTypeName factoryInterface =
+        ParameterizedTypeName.get(ClassName.get(ObjectRefFactory.class), ref);
+
+    TypeSpec impl =
+        TypeSpec.anonymousClassBuilder("")
+            .addSuperinterface(factoryInterface)
+            .addField(
+                FieldSpec.builder(
+                        String.class, "kind", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                    .initializer("$T.of(\"\").kind()", ref)
+                    .build())
+
+            // getRefClass()
+            .addMethod(
+                MethodSpec.methodBuilder("getRefClass")
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(ParameterizedTypeName.get(ClassName.get(Class.class), ref))
+                    .addStatement("return $T.class", ref)
+                    .build())
+
+            // create(String id)
+            .addMethod(
+                MethodSpec.methodBuilder("create")
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC)
+                    .addParameter(String.class, "id")
+                    .returns(ref)
+                    .addStatement("return $T.of(id)", ref)
+                    .build())
+
+            // kind()
+            .addMethod(
+                MethodSpec.methodBuilder("kind")
+                    .addAnnotation(Override.class)
+                    .addModifiers(Modifier.PUBLIC)
+                    .returns(String.class)
+                    .addStatement("return kind")
+                    .build())
+            .build();
+
+    factories.addField(
+        FieldSpec.builder(
+                factoryInterface,
+                ref.simpleName().toUpperCase(),
+                Modifier.PUBLIC,
+                Modifier.STATIC,
+                Modifier.FINAL)
+            .initializer("$L", impl)
+            .build());
   }
 
   private void addCheckMethods(TypeSpec.Builder typeRefBuilder, ObjectDefinition definition) {
@@ -183,16 +271,53 @@ public class SpiceDbClientGeneratorImpl implements SpiceDbClientGenerator {
               .returns(ClassName.get(CheckPermission.class))
               .addCode(
                   """
-                    if ($L == null) {
-                     throw new IllegalArgumentException("subject must not be null");
-                    }
-                    return CheckPermission.newBuilder().resource(this).permission($S).subject($L).consistency($L).build();
-                  """,
+                if ($L == null) {
+                 throw new IllegalArgumentException("subject must not be null");
+                }
+                return CheckPermission.newBuilder().resource(this).permission($S).subject($L).consistency($L).build();
+              """,
                   subjectParamName,
                   permission.name(),
                   subjectParamName,
                   consistencyParamName)
               .build());
+    }
+  }
+
+  private void addLookupMethods(TypeSpec.Builder typeRefBuilder, ObjectDefinition definition) {
+    for (Permission permission : definition.permissions()) {
+
+      var allowedObjectTypes =
+          definition.relations().stream()
+              .flatMap(relation -> relation.allowedObjects().stream())
+              .filter(objectTypeRef -> objectTypeRef.relationship() == null)
+              .map(ObjectTypeRef::typeName)
+              .toList();
+
+      var permissionName = TextUtils.toPascalCase(permission.name());
+
+      for (String allowedObjectType : allowedObjectTypes) {
+
+        // TODO magic ref
+        String refType = toPascalCase(allowedObjectType);
+        var typeRefName = refType + "Ref";
+
+        ClassName className = ClassName.bestGuess(typeRefName);
+        var lookupMethodName = "lookup" + permissionName + refType;
+
+        typeRefBuilder.addMethod(
+            MethodSpec.methodBuilder(lookupMethodName)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(LookupSuspects.class), className))
+                .addCode(
+                    """
+                  return LookupSuspects.<$T>newBuilder().resource(this).permission($S).subjectType(ObjectRefFactories.$L).build();
+                """,
+                    className,
+                    permission.name(),
+                    className.simpleName().toUpperCase())
+                .build());
+      }
     }
   }
 
@@ -223,11 +348,11 @@ public class SpiceDbClientGeneratorImpl implements SpiceDbClientGenerator {
                 .returns(updateRelationshipTypeName)
                 .addCode(
                     """
-                                if ($L == null) {
-                                 throw new IllegalArgumentException("ref must not be null");
-                                }
-                                return $T.ofUpdate(this, $S, $T.ofObjectWithRelation($L, $S));
-                                """,
+                    if ($L == null) {
+                     throw new IllegalArgumentException("ref must not be null");
+                    }
+                    return $T.ofUpdate(this, $S, $T.ofObjectWithRelation($L, $S));
+                    """,
                     "ref",
                     updateRelationshipTypeName,
                     relation.name(),
@@ -250,11 +375,11 @@ public class SpiceDbClientGeneratorImpl implements SpiceDbClientGenerator {
                 .returns(ClassName.bestGuess("UpdateRelationship"))
                 .addCode(
                     """
-                                            if ($L == null) {
-                                             throw new IllegalArgumentException("ref must not be null");
-                                            }
-                                            return $T.ofDelete(this, $S, SubjectRef.ofObjectWithRelation($L, $S));
-                                            """,
+                    if ($L == null) {
+                     throw new IllegalArgumentException("ref must not be null");
+                    }
+                    return $T.ofDelete(this, $S, SubjectRef.ofObjectWithRelation($L, $S));
+                    """,
                     "ref",
                     updateRelationshipTypeName,
                     relation.name(),

--- a/spicedb-binding/src/main/java/com/oviva/spicegen/spicedbbinding/internal/SpiceDbPermissionServiceImpl.java
+++ b/spicedb-binding/src/main/java/com/oviva/spicegen/spicedbbinding/internal/SpiceDbPermissionServiceImpl.java
@@ -4,6 +4,10 @@ import com.authzed.api.v1.*;
 import com.oviva.spicegen.api.*;
 import com.oviva.spicegen.api.PermissionService;
 import io.grpc.StatusRuntimeException;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
 
 public class SpiceDbPermissionServiceImpl implements PermissionService {
 
@@ -59,6 +63,31 @@ public class SpiceDbPermissionServiceImpl implements PermissionService {
       var response = permissionsService.checkPermission(request);
       return response.getPermissionship()
           == CheckPermissionResponse.Permissionship.PERMISSIONSHIP_HAS_PERMISSION;
+    } catch (StatusRuntimeException e) {
+      throw exceptionMapper.map(e);
+    }
+  }
+
+  @Override
+  public <T extends ObjectRef> Iterator<T> lookupSubjects(LookupSuspects<T> lookupSuspects) {
+
+    var request =
+        LookupSubjectsRequest.newBuilder()
+            .setPermission(lookupSuspects.permission())
+            .setSubjectObjectType(lookupSuspects.subjectType().kind())
+            .setResource(objectReferenceMapper.map(lookupSuspects.resource()))
+            .build();
+
+    try {
+      var response = permissionsService.lookupSubjects(request);
+      return StreamSupport.stream(
+              Spliterators.spliteratorUnknownSize(response, Spliterator.ORDERED), false)
+          .map(
+              lookupSubjectsResponse ->
+                  lookupSuspects
+                      .subjectType()
+                      .create(lookupSubjectsResponse.getSubject().getSubjectObjectId()))
+          .iterator();
     } catch (StatusRuntimeException e) {
       throw exceptionMapper.map(e);
     }


### PR DESCRIPTION
Introduce `LookupSuspects` interface and integrate subject lookup functionality into `PermissionService`. Extend the code generator to support methods for subject lookups and create factories for `ObjectRef` instances.